### PR TITLE
8560p UUID patch

### DIFF
--- a/BiosSledgehammer.ps1
+++ b/BiosSledgehammer.ps1
@@ -1,6 +1,6 @@
 <#
  BiosSledgehammer
- Copyright © 2015-2017 Michael 'Tex' Hex 
+ Copyright Â© 2015-2017 Michael 'Tex' Hex 
  Licensed under the Apache License, Version 2.0. 
 
  https://github.com/texhex/BiosSledgehammer
@@ -58,7 +58,7 @@ $banner=@"
             _
     jgs   ./ |   
          /  /    BIOS Sledgehammer Version @@VERSION@@
-       /'  /     Copyright © 2015-2017 Michael 'Tex' Hex
+       /'  /     Copyright Â© 2015-2017 Michael 'Tex' Hex
       /   /      
      /    \      https://github.com/texhex/BiosSledgehammer
     |      ``\   
@@ -83,12 +83,12 @@ write-host $banner
 
 #Configure which BCU version to use 
 #Version 2.45 and upwards: BCU 4.0.21.1
-Set-Variable BCU_EXE_SOURCE "$PSScriptRoot\BCU-4.0.21.1\BiosConfigUtility64.exe" –option ReadOnly -Force
+Set-Variable BCU_EXE_SOURCE "$PSScriptRoot\BCU-4.0.21.1\BiosConfigUtility64.exe" â€“option ReadOnly -Force
   #for testing if the arguments are correctly sent to BCU
-  #Set-Variable BCU_EXE "$PSScriptRoot\4.0.15.1\EchoArgs.exe" –option ReadOnly -Force
+  #Set-Variable BCU_EXE "$PSScriptRoot\4.0.15.1\EchoArgs.exe" â€“option ReadOnly -Force
 
 #Configute which ISA00075 version to use
-Set-Variable ISA75DT_EXE_SOURCE "$PSScriptRoot\ISA75DT-1.0.1.39\Windows\Intel-SA-00075-console.exe" –option ReadOnly -Force
+Set-Variable ISA75DT_EXE_SOURCE "$PSScriptRoot\ISA75DT-1.0.1.39\Windows\Intel-SA-00075-console.exe" â€“option ReadOnly -Force
 
 
 #For performance issues (AV software that keeps scanning EXEs from network) we copy BCU locally
@@ -96,17 +96,17 @@ Set-Variable ISA75DT_EXE_SOURCE "$PSScriptRoot\ISA75DT-1.0.1.39\Windows\Intel-SA
 Set-Variable BCU_EXE "" -Force
 
 #Path to password files (need to have extension *.bin)
-Set-Variable PWDFILES_PATH "$PSScriptRoot\PwdFiles" –option ReadOnly -Force
+Set-Variable PWDFILES_PATH "$PSScriptRoot\PwdFiles" â€“option ReadOnly -Force
 
 #Will store the currently used password file (copied locally)
 #File will be deleted when the script finishes
 Set-Variable CurrentPasswordFile "" -Force
 
 #Path to model files
-Set-Variable MODELS_PATH "$PSScriptRoot\Models" –option ReadOnly -Force
+Set-Variable MODELS_PATH "$PSScriptRoot\Models" â€“option ReadOnly -Force
 
 #Common exit code
-Set-Variable ERROR_SUCCESS_REBOOT_REQUIRED 3010 –option ReadOnly -Force
+Set-Variable ERROR_SUCCESS_REBOOT_REQUIRED 3010 â€“option ReadOnly -Force
 
 
 
@@ -176,8 +176,9 @@ function Test-BiosCommunication()
 
   #At least the ProDesk 600 G1 uses the name "Enter UUID"
   #Newer models use "Universally Unique Identifier (UUID)"
+  #raynorpat: my 8560p here uses "Universal Unique Identifier(UUID)", not sure about other older models...
 
-  $UUIDNames=@("Universally Unique Identifier (UUID)", "Enter UUID")
+  $UUIDNames=@("Universally Unique Identifier (UUID)", "Enter UUID", "Universal Unique Identifier(UUID)")
 
   $UUID=Get-BiosValue -Names $UUIDNames -Silent
 
@@ -270,7 +271,7 @@ function ConvertTo-DescriptionFromBCUReturncode()
  $lookup=
  @{ 
   "0"="Success"; "1"="Not Supported"; "2"="Unknown"; "3"="Timeout"; "4"="Failed"; "5"="Invalid Parameter"; "6"="Access Denied";
-  "10"="Valid password not provided"; "11"="Config file not valid"; "12"="First line in config file is not the BIOSConfig”;
+  "10"="Valid password not provided"; "11"="Config file not valid"; "12"="First line in config file is not the BIOSConfigâ€;
   "13"="Failed to change setting"; "14"="BCU not ready to write file."; "15"="Command line syntax error."; "16"="Unable to write to file or system";
   "17"="Help is invoked"; "18"="Setting is unchanged"; "19"="Setting is read-only"; "20"="Invalid setting name"; "21"="Invalid setting value";
   "23"="Unable to connect to HP BIOS WMI namespace"; "24"="Unable to connect to HP WMI namespace."; "25"="Unable to connect to PUBLIC WMI namespace";
@@ -784,7 +785,7 @@ function Test-BiosPasswordFiles()
   [string]$PwdFilesFolder
  )   
   
-  Set-Variable ASSET_NAME "Asset Tracking Number" –option ReadOnly -Force
+  Set-Variable ASSET_NAME "Asset Tracking Number" â€“option ReadOnly -Force
 
   Write-HostSection -Start "Determine BIOS Password"
 


### PR DESCRIPTION
Fixed issue when running on 8560p laptops where the UUID is not found.

Adding "Universal Unique Identifier(UUID)" to the list of UUIDNames fixes this issue.